### PR TITLE
termpty (_termpty_cell_is_empty): fix a problem that the cells of bg/fgcolor 9 are wrongly detected as empty cells (Fix #95)

### DIFF
--- a/src/bin/termpty.c
+++ b/src/bin/termpty.c
@@ -924,8 +924,8 @@ _termpty_cell_is_empty(const Termcell *cell)
 {
    return ((cell->codepoint == 0) ||
            (cell->att.invisible) ||
-           (cell->att.fg == COL_INVIS)) &&
-      ((cell->att.bg == COL_INVIS) || (cell->att.bg == COL_DEF));
+           ((cell->att.fg256 == 0) && (cell->att.fg == COL_INVIS))) &&
+      (((cell->att.bg256 == 0) && (cell->att.bg == COL_INVIS)) || (cell->att.bg == COL_DEF));
 }
 
 static Eina_Bool

--- a/tests/colors_regression.sh
+++ b/tests/colors_regression.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Regression test for color 9 confused with COL_INVIS
+# (cf https://github.com/borisfaure/terminology/issues/95)
+printf '\033[38;5;9mhello\033[0m\n'
+
+# By using the window manipulation sequence, we induce "termpty_resize
+# (termpty.c:1339)" where "termpty_line_length (termpty.c:949)" is used .
+# "termpty_line_length" uses "_termpty_cell_is_empty" that had a bug.
+printf '\033[8;25;132t'
+printf '\033[8;25;80t'

--- a/tests/tests.results
+++ b/tests/tests.results
@@ -31,6 +31,7 @@ dsr-os.sh 0c233ebe0c97c3650b507e927ec92abf
 dsr-pp.sh 35733eed0b451ad87357a22d189ac26f
 dsr-udk.sh f53a390493267764cdc7c488d51e55ec
 colors.sh 103d3e6b2e89424ff886576cfaeb5d55
+colors_regression.sh 5521278732a4c3fc299e3940f620d0c2
 sgr-leading-trailing-semicolon.sh 57d81e2a5e70188911bff0c166a5be56
 sgr-truecolors.sh b7b8981b7f44c1cba656e6aa3a1b928f
 hang-invalid-truecolors.sh 6d3f407a3fc877e7687a1ed4022c300d


### PR DESCRIPTION
This PR fixes #95. The reduced reproducer for the issue reported at #95 is this:

```bash
bash$ printf '\e[38;5;9mhello\e[m\n'
```

**Before the fix**

![image](https://user-images.githubusercontent.com/8982192/158139579-a6d664c6-7814-46e1-b14b-09a27ec8c008.png)

This is because the function [`_termpty_cell_is_empty`](https://github.com/borisfaure/terminology/blob/4d7dad2a798bab34d7fc0da8e06196c4310b2945/src/bin/termpty.c#L923) fails to distinguish color 9 of 256 index colors from the special color value [`COL_INVIS`](https://github.com/borisfaure/terminology/blob/4d7dad2a798bab34d7fc0da8e06196c4310b2945/src/bin/termpty.h#L27) (defined to be 9). `_termpty_cell_is_empty` should also check the data members `att.fg256` and `att.bg256`.

I have added a fix 40bd9a01 along with a test 7e4ab152. In this patch, the background color 0 is intentionally kept treated as `COL_DEF`, but this might cause glitches when the user uses a color other than black as the default background color.

**After the fix**

![image](https://user-images.githubusercontent.com/8982192/158141980-a3599574-eaab-42b2-80e4-0dc1466a31dc.png)
